### PR TITLE
Ajuste de estilos en íconos

### DIFF
--- a/lib/Header/Menu/styles.js
+++ b/lib/Header/Menu/styles.js
@@ -52,7 +52,9 @@ export default {
         height:icons.menu.height,
         display:icons.menu.display,
         transition:'0.3s all',
-        background:icons.base(icons.menu.icon(["#FFFFFF"]))
+        background:icons.base(icons.menu.icon(["#FFFFFF"])),
+        backgroundRepeat:'no-repeat',
+        backgroundPosition:'center center'        
     },
     dropdownMenu: {
         position:'absolute',

--- a/lib/Header/Nav/styles.js
+++ b/lib/Header/Nav/styles.js
@@ -25,7 +25,10 @@ export default {
             color:colors.darkBlueH
         }
     },
-    icon: {},
+    icon: {
+        backgroundRepeat:'no-repeat',
+        backgroundPosition:'center center'
+    },
     activeItem: {
         '& $icon, &:hover $icon': {
             filter:'brightness(1)'

--- a/lib/SightLogo/styles.js
+++ b/lib/SightLogo/styles.js
@@ -11,6 +11,8 @@ export default {
         height:icons.sight.height,
         display:icons.sight.display,
         background:icons.base(icons.sight.icon(["#FFFFFF"])),
-        marginTop:'6px'
+        marginTop:'6px',
+        backgroundPosition:'center center',
+        backgroundRepeat:'no-repeat'
     }
 };


### PR DESCRIPTION
Modificaciones para icónos de la barra de encabezado en Sight
### BEFORE

### AFTER
Se agregan a los íconos de Sight, nav y Menú en la barra del encabezado
* background-repeat: no-repeat
* background-position: center center