### PR TITLE
TextField's inputMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## 1.15.x
 
+### 1.15.4
+
+- New `inputMode` prop in `TextField` component.
+
 ### 1.15.3
 
 - Fix in the input type for the `TextField` component with mask prop.

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -128,7 +128,7 @@ class TextField extends React.Component {
 
     render() {
         const { status, value, touched, showPass, passIconBeingClicked } = this.state;
-        const { classes, input, meta, label, placeholder, counter, maxLength, type, name, options, id, style, disabled, autoFocus, error, assistiveText, clear, iconName, allowError, lockHeight, required, mask, guide, disableAutoComplete, pattern } = this.props;
+        const { classes, input, meta, label, placeholder, counter, maxLength, type, name, options, id, style, disabled, autoFocus, error, assistiveText, clear, iconName, allowError, lockHeight, required, mask, guide, inputMode, disableAutoComplete, pattern } = this.props;
         let realStatus = status;
         let InputType = (type == "select" ? "select" : type == "textarea" ? "textarea" : "input");
         const errorStatus = (meta && meta.error && (meta.touched || allowError)) || (error && (touched || allowError)) && !passIconBeingClicked;
@@ -150,7 +150,8 @@ class TextField extends React.Component {
             onKeyUp:this.onKeyUp,
             ref:ref => { this.input = ref; },
             required,
-            pattern
+            pattern,
+            inputMode
         };
         if (disabled) {
             if (type == "select") {
@@ -325,6 +326,8 @@ TextField.propTypes = {
     ]),
     /** Boolean to show or hide the full mask while writing. */
     guide: PropTypes.bool,
+    /** The type of input the field will receive, to show the right keyboard in mobile. */
+    inputMode: PropTypes.oneOf(['none', 'text', 'decimal', 'numeric', 'tel', 'search', 'email', 'url']),
     /**  Disables native autoComplete on browsers. */
     disableAutoComplete: PropTypes.bool,
     /** Metadata sended by react-form. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@occmundial/occ-atomic",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Collection of shareable styled React components for OCC applications.",
   "homepage": "http://occmundial.github.io/occ-atomic",
   "main": "build/index.js",


### PR DESCRIPTION
# Description
The new inputMode prop lets you decide which keyboard layout you want to show on mobile:
'none', 'text', 'decimal', 'numeric', 'tel', 'search', 'email', 'url'