### PR TITLE
feat: Implement babel plugin

### DIFF
--- a/lib/plugin/babel.js
+++ b/lib/plugin/babel.js
@@ -1,0 +1,76 @@
+const types = require('@babel/types');
+
+function error(msg) {
+    throw new Error(`babel-plugin-occ-atomic: ${msg}`);
+}
+
+function getImportsList(path) {
+    return path.node.specifiers.filter(function (specifier) {
+        if (specifier.type !== 'ImportSpecifier') {
+            error(
+                'Import entire module detected. Using this syntax means we cannot tree shake properly.'
+            );
+        } else return true;
+    });
+}
+
+function importDeclaration(specifier, path) {
+    return types.importDeclaration([specifier], types.stringLiteral(path));
+}
+
+function replaceImport(path, statements) {
+    if (statements.length > 0) {
+        path.replaceWithMultiple(statements);
+    }
+    return path;
+}
+
+const subatomic = [
+    'colors',
+    'fonts',
+    'grid',
+    'icons',
+    'iconSizes',
+    'shadows',
+    'spacing'
+];
+
+function importModule(path) {
+    const importsList = getImportsList(path);
+    const importStatements = importsList.map(function (specifier) {
+        const importName = specifier.imported.name;
+        if (importName === 'toaster') {
+            return importDeclaration(
+                specifier,
+                '@occmundial/occ-atomic/build/Toaster/functions'
+            );
+        } else if (importName === 'Nav' || importName === 'Menu') {
+            return importDeclaration(
+                specifier,
+                `@occmundial/occ-atomic/build/Header/${importName}`
+            );
+        } else if (subatomic.includes(importName)) {
+            return importDeclaration(
+                types.importDefaultSpecifier(types.identifier(importName)),
+                `@occmundial/occ-atomic/build/subatomic/${importName}`
+            );
+        }
+        return importDeclaration(
+            types.importDefaultSpecifier(types.identifier(importName)),
+            `@occmundial/occ-atomic/build/${importName}`
+        );
+    });
+    replaceImport(path, importStatements);
+}
+
+module.exports = function () {
+    return {
+        visitor: {
+            ImportDeclaration: function (path) {
+                if (path.node.source.value === '@occmundial/occ-atomic') {
+                    return importModule(path);
+                }
+            }
+        }
+    };
+};


### PR DESCRIPTION
The babel plugin optimizes the bundle size, including only the used components in it.

To implement the babel plugin in your project include it as a plugin in the .babelrc file:

```
{
	"plugins": [
		...
		"@occmundial/occ-atomic/build/plugin/babel",
                ...
        ]
}
```

### Note
For some reason the use of the plugin presents some errors when using aliases on the atomic imports, like:
```
import { Footer as AtomicFooter } from '@occmundial/occ-atomic'
```
If you're alising the import because you have a variable with the same name on your file this will crash the build, so better rename your variable instead of the import.